### PR TITLE
Remove "Development" from Welcome page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,6 @@ nav:
       - How it works: "how-it-works.md"
       - Troubleshooting: "troubleshooting.md"
       - kubectl plugin: "kubectl-plugin.md"
-      - Development: "development.md"
   - Deployment:
       - Installation Guide: "deploy/index.md"
       - Bare-metal considerations: "deploy/baremetal.md"


### PR DESCRIPTION
 ## What this PR does / why we need it:
This PR is for documentation. The development.md file does not exist. Clicking on "Development" link on the Welcome page returns a 404.

## Types of changes
We already have a Developer Guide. Having the Development page should not be required. Hence, I am proposing that we remove it.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
